### PR TITLE
ci: update github actions/node versions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@v2.5.1
+      - name: Set Node.js 18.x
+        uses: actions/setup-node@v3.5.1
         with:
-          node-version: 12.x
+          node-version: 18.12.1
 
       - name: Install dependencies
         run: npm ci
@@ -46,7 +46,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist


### PR DESCRIPTION
Fix security warning caused by outdated node version